### PR TITLE
Layout overhaul: sidebar studio, compare grid, theater preview, E2E tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.env
 *.dev
 .DS_Store
+node_modules/
+test-results/
+playwright-report/
+.playwright-cache/

--- a/README.md
+++ b/README.md
@@ -18,20 +18,30 @@
 ## Quick start
 
 1. Open the [hosted demo](https://ajmeese7.github.io/readme-ascii/), or your fork's GitHub Pages URL.
-2. Enter a short project or profile name.
-3. (Optional) open the advanced settings to tweak text color, background color, or shadow.
-4. Click **Generate Image**, then **Download**.
+2. Enter your text in the sidebar. The preview updates live as you type.
+3. Tweak font, text color, background color, transparency, and shadow.
+4. Click **Compare fonts** to see the same text rendered across every available font; click a card to promote it into an inline theater preview and select that font.
+5. Click **Download** to save the PNG.
 
 ### Local development
 
-Pure static site, no build step. Either:
+Runtime is a pure static site (no build step). The dev toolchain is Node-only:
 
 ```bash
-# Open the file directly
-xdg-open index.html
+npm install
+npm start        # serves the site at http://localhost:8123/
+```
 
-# Or serve over HTTP (recommended; some browsers restrict figlet's font fetch under file://)
-npx serve .
+(`npm start` runs [`serve`](https://www.npmjs.com/package/serve). You can also open `index.html` directly, but some browsers restrict figlet's font fetch under `file://`.)
+
+### Tests
+
+End-to-end tests cover the live preview, compare grid, and theater focus panel. They use Playwright and start their own static server on port `8124`:
+
+```bash
+npx playwright install chromium  # one-time browser download
+npm test                          # headless
+npm run test:headed               # watch in a browser window
 ```
 
 ## Deployment

--- a/index.css
+++ b/index.css
@@ -402,6 +402,69 @@ input[type="color"]:disabled {
     position: absolute;
 }
 
+/* --- Font focus (theater) panel --- */
+#fontFocus {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--panel-bg);
+}
+
+/* ID specificity overrides UA [hidden]; re-assert explicitly. */
+#fontFocus[hidden],
+#fontGrid[hidden] {
+    display: none;
+}
+
+.font-focus-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.font-focus-label {
+    font-size: 1rem;
+    font-weight: 500;
+    color: var(--fg);
+}
+
+.font-focus-close {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: 1px solid var(--input-border);
+    background: transparent;
+    color: var(--fg);
+    font-size: 15px;
+    line-height: 1;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease;
+    flex-shrink: 0;
+}
+
+.font-focus-close:hover {
+    background: var(--btn-hover-bg);
+    color: var(--btn-hover-fg);
+}
+
+.font-focus-image {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: auto;
+}
+
+.font-focus-image img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+}
+
 /* --- Mobile --- */
 @media (max-width: 720px) {
     .app {

--- a/index.css
+++ b/index.css
@@ -312,6 +312,83 @@ label {
     to { transform: rotate(360deg); }
 }
 
+/* --- Font compare grid --- */
+#fontGrid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 16px;
+    margin: 30px auto 0;
+    width: 100%;
+}
+
+.font-card {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px;
+    border: 1px solid var(--input-border);
+    border-radius: 6px;
+    background: var(--input-bg);
+    cursor: pointer;
+    transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.font-card:hover {
+    border-color: var(--btn-border);
+    transform: translateY(-2px);
+}
+
+.font-card.active {
+    border-color: var(--success-border);
+    box-shadow: 0 0 0 2px var(--success-border);
+}
+
+.font-card-label {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--muted-fg);
+    text-align: center;
+}
+
+.font-card-preview {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100px;
+    max-height: 140px;
+    overflow: hidden;
+    border-radius: 4px;
+}
+
+.font-card-preview img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+    display: block;
+}
+
+.font-card-preview.error {
+    color: var(--muted-fg);
+    font-size: 0.8rem;
+    font-style: italic;
+}
+
+.font-card-preview.loading {
+    position: relative;
+}
+
+.font-card-preview.loading::after {
+    content: "";
+    width: 1.25rem;
+    height: 1.25rem;
+    border: 0.2em solid var(--input-border);
+    border-top-color: var(--fg);
+    border-radius: 50%;
+    animation: spin 0.75s linear infinite;
+    position: absolute;
+}
+
 @media (max-width: 480px) {
     body {
         padding: 12px;
@@ -325,5 +402,8 @@ label {
         width: 36px;
         height: 36px;
         font-size: 16px;
+    }
+    #fontGrid {
+        grid-template-columns: 1fr;
     }
 }

--- a/index.css
+++ b/index.css
@@ -3,6 +3,7 @@
     --bg: #ffffff;
     --fg: #212529;
     --muted-fg: #6c757d;
+    --panel-bg: #f7f7f8;
     --input-bg: #ffffff;
     --input-fg: #212529;
     --input-border: #ced4da;
@@ -20,6 +21,7 @@
     --secondary-hover-bg: #6c757d;
     --secondary-hover-fg: #ffffff;
     --glow-color: 255, 193, 7;
+    --border: #e5e7eb;
 }
 
 [data-theme="dark"] {
@@ -27,6 +29,7 @@
     --bg: #1a1a1a;
     --fg: #e8e8e8;
     --muted-fg: #9aa0a6;
+    --panel-bg: #202020;
     --input-bg: #2a2a2a;
     --input-fg: #e8e8e8;
     --input-border: #3f3f3f;
@@ -44,31 +47,49 @@
     --secondary-hover-bg: #666666;
     --secondary-hover-fg: #ffffff;
     --glow-color: 147, 197, 253;
+    --border: #2f2f2f;
 }
 
 * {
     box-sizing: border-box;
 }
 
+html, body {
+    height: 100%;
+}
+
 body {
-    max-width: 1000px;
-    margin: 0 auto;
-    padding: 16px;
+    margin: 0;
     background: var(--bg);
     color: var(--fg);
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
     transition: background 0.2s ease, color 0.2s ease;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
 }
 
-body > a {
-    display: block;
+/* --- Topbar --- */
+.topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg);
+    gap: 12px;
 }
 
-.banner, #result {
+.brand {
+    display: inline-flex;
+    align-items: center;
+    text-decoration: none;
+}
+
+.brand-logo {
+    height: 36px;
+    width: auto;
     display: block;
-    margin: 25px auto 0;
-    max-width: 100%;
-    height: auto;
 }
 
 .banner-dark {
@@ -83,35 +104,22 @@ body > a {
     display: block;
 }
 
-#userInput {
-    width: fit-content;
-    max-width: 100%;
-    margin: 40px auto 0;
-}
-
-#userInput p {
-    text-align: center;
-}
-
 /* --- Theme toggle --- */
 #themeToggle {
-    position: fixed;
-    top: 12px;
-    right: 12px;
-    z-index: 100;
-    width: 40px;
-    height: 40px;
+    width: 36px;
+    height: 36px;
     border: 1px solid var(--btn-border);
     border-radius: 50%;
     background: var(--bg);
     color: var(--fg);
-    font-size: 18px;
+    font-size: 16px;
     line-height: 1;
     cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
     transition: transform 0.15s ease, background 0.2s ease, color 0.2s ease;
+    flex-shrink: 0;
 }
 
 #themeToggle:hover {
@@ -131,7 +139,51 @@ body > a {
     }
 }
 
+/* --- App layout --- */
+.app {
+    flex: 1;
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    min-height: 0;
+}
+
+.sidebar {
+    background: var(--panel-bg);
+    border-right: 1px solid var(--border);
+    padding: 20px 18px;
+    overflow-y: auto;
+}
+
+.canvas {
+    padding: 24px;
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 16px;
+}
+
 /* --- Form controls --- */
+#userInput {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+label {
+    display: block;
+    font-weight: 500;
+    margin-top: 10px;
+    margin-bottom: 4px;
+    color: var(--fg);
+    font-size: 0.9rem;
+}
+
+#userInput > label:first-of-type {
+    margin-top: 0;
+}
+
 input[type="text"],
 select {
     background: var(--input-bg);
@@ -142,8 +194,7 @@ select {
     font-family: inherit;
     font-size: 1rem;
     line-height: 1.5;
-    width: 200px;
-    max-width: 100%;
+    width: 100%;
 }
 
 input[type="text"]:focus,
@@ -154,8 +205,7 @@ select:focus {
 }
 
 input[type="color"] {
-    width: 200px;
-    max-width: 100%;
+    width: 100%;
     height: 38px;
     padding: 2px;
     border: 1px solid var(--input-border);
@@ -169,55 +219,16 @@ input[type="color"]:disabled {
     opacity: 0.5;
 }
 
-label {
-    display: block;
-    font-weight: 500;
-    margin-bottom: .3rem;
-    color: var(--fg);
-}
-
 .checkbox-row {
     display: flex;
     align-items: center;
     gap: 6px;
-    margin-top: 8px;
+    margin-top: 10px;
 }
 
 .checkbox-row label {
-    margin-bottom: 0;
+    margin: 0;
     font-weight: 400;
-}
-
-#asciiGroup {
-    display: flex;
-    width: 266px;
-    max-width: 100%;
-    margin: 0 auto;
-}
-
-#asciiGroup #asciiText {
-    flex: 1 1 auto;
-    width: auto;
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-    border-right: none;
-}
-
-#asciiGroup #dropdown {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-    padding: 6px 10px;
-}
-
-#advanced {
-    display: none;
-    width: 243px;
-    max-width: 100%;
-    margin: 12px auto 0;
-}
-
-#advanced > label:not(:first-child) {
-    margin-top: 10px;
 }
 
 /* --- Buttons --- */
@@ -270,9 +281,7 @@ label {
 }
 
 #buttons {
-    width: 266px;
-    max-width: 100%;
-    margin: 12px auto 0;
+    margin-top: 18px;
     display: flex;
     flex-direction: column;
     gap: 8px;
@@ -287,11 +296,16 @@ label {
     width: 100%;
 }
 
-/* --- Spinner --- */
+/* --- Canvas / preview --- */
+#result {
+    max-width: 100%;
+    height: auto;
+    display: block;
+}
+
 .spinner-container {
     display: flex;
     justify-content: center;
-    margin-top: 60px;
     visibility: hidden;
 }
 
@@ -317,7 +331,6 @@ label {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
     gap: 16px;
-    margin: 30px auto 0;
     width: 100%;
 }
 
@@ -389,21 +402,23 @@ label {
     position: absolute;
 }
 
-@media (max-width: 480px) {
-    body {
-        padding: 12px;
-    }
-    #userInput {
-        margin-top: 24px;
-    }
-    #themeToggle {
-        top: 8px;
-        right: 8px;
-        width: 36px;
-        height: 36px;
-        font-size: 16px;
-    }
-    #fontGrid {
+/* --- Mobile --- */
+@media (max-width: 720px) {
+    .app {
         grid-template-columns: 1fr;
+    }
+    .sidebar {
+        border-right: none;
+        border-bottom: 1px solid var(--border);
+        padding: 16px;
+    }
+    .canvas {
+        padding: 16px;
+    }
+    .topbar {
+        padding: 8px 12px;
+    }
+    .brand-logo {
+        height: 28px;
     }
 }

--- a/index.html
+++ b/index.html
@@ -2,10 +2,27 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>README ASCII</title>
+        <title>readme-ascii, ASCII art banner generator</title>
 
         <link rel="icon" type="image/png" href="favicon.png">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+
+        <meta name="description" content="Turn a line of text into a crisp PNG banner, perfect for GitHub READMEs. Live preview, font picker, light or dark themes.">
+
+        <link rel="canonical" href="https://ajmeese7.github.io/readme-ascii/">
+        <meta property="og:type" content="website">
+        <meta property="og:site_name" content="readme-ascii">
+        <meta property="og:title" content="readme-ascii">
+        <meta property="og:description" content="Turn a line of text into a crisp PNG banner, perfect for GitHub READMEs.">
+        <meta property="og:url" content="https://ajmeese7.github.io/readme-ascii/">
+        <meta property="og:image" content="https://ajmeese7.github.io/readme-ascii/ASCII.png">
+        <meta property="og:image:alt" content="readme-ascii ASCII art logo">
+
+        <meta name="twitter:card" content="summary_large_image">
+        <meta name="twitter:title" content="readme-ascii">
+        <meta name="twitter:description" content="Turn a line of text into a crisp PNG banner, perfect for GitHub READMEs.">
+        <meta name="twitter:image" content="https://ajmeese7.github.io/readme-ascii/ASCII.png">
+
         <link rel="stylesheet" href="index.css">
 
         <script>
@@ -40,77 +57,78 @@
     </head>
 
     <body>
-        <button id="themeToggle" type="button" aria-label="Toggle light/dark theme">🌙</button>
-        <script>
-            // Set the toggle glyph synchronously so it matches the pre-paint theme.
-            (function() {
-                var btn = document.getElementById("themeToggle");
-                if (btn) btn.textContent = document.documentElement.getAttribute("data-theme") === "dark" ? "\u{2600}\u{FE0F}" : "\u{1F319}";
-            })();
-        </script>
+        <header class="topbar">
+            <a class="brand" href="https://github.com/ajmeese7/readme-ascii" aria-label="readme-ascii on GitHub">
+                <img src="ASCII.png" class="brand-logo banner-light" alt="readme-ascii" />
+                <img src="ASCII_light.png" class="brand-logo banner-dark" alt="readme-ascii" />
+            </a>
+            <button id="themeToggle" type="button" aria-label="Toggle light/dark theme">🌙</button>
+            <script>
+                // Set the toggle glyph synchronously so it matches the pre-paint theme.
+                (function() {
+                    var btn = document.getElementById("themeToggle");
+                    if (btn) btn.textContent = document.documentElement.getAttribute("data-theme") === "dark" ? "\u{2600}\u{FE0F}" : "\u{1F319}";
+                })();
+            </script>
+        </header>
 
-        <a href="https://github.com/ajmeese7/readme-ascii">
-            <img src="ASCII.png" class="banner banner-light" alt="README ASCII" />
-            <img src="ASCII_light.png" class="banner banner-dark" alt="README ASCII" />
-        </a>
+        <main class="app">
+            <aside class="sidebar">
+                <form id="userInput">
+                    <label for="asciiText">Text</label>
+                    <input id="asciiText" type="text" required placeholder="README ASCII" />
 
-        <form id="userInput">
-            <p>Enter your text for ASCII-ification:</p>
-            <div id="asciiGroup">
-                <input id="asciiText" type="text" required placeholder="README ASCII" />
-                <button id="dropdown" class="btn btn-secondary" type="button" aria-label="Toggle advanced settings">▼</button>
-            </div>
+                    <label for="font">Font</label>
+                    <select id="font">
+                        <option value="Alpha" selected>Alpha</option>
+                        <option value="ANSI Shadow">ANSI Shadow</option>
+                        <option value="Banner3">Banner3</option>
+                        <option value="Big">Big</option>
+                        <option value="Block">Block</option>
+                        <option value="Bloody">Bloody</option>
+                        <option value="Colossal">Colossal</option>
+                        <option value="Doom">Doom</option>
+                        <option value="DOS Rebel">DOS Rebel</option>
+                        <option value="Ghost">Ghost</option>
+                        <option value="Larry 3D">Larry 3D</option>
+                        <option value="Roman">Roman</option>
+                        <option value="Shadow">Shadow</option>
+                        <option value="Slant">Slant</option>
+                        <option value="Standard">Standard</option>
+                        <option value="Star Wars">Star Wars</option>
+                    </select>
 
-            <div id="advanced">
-                <label for="font">Font</label>
-                <select id="font">
-                    <option value="Alpha" selected>Alpha</option>
-                    <option value="ANSI Shadow">ANSI Shadow</option>
-                    <option value="Banner3">Banner3</option>
-                    <option value="Big">Big</option>
-                    <option value="Block">Block</option>
-                    <option value="Bloody">Bloody</option>
-                    <option value="Colossal">Colossal</option>
-                    <option value="Doom">Doom</option>
-                    <option value="DOS Rebel">DOS Rebel</option>
-                    <option value="Ghost">Ghost</option>
-                    <option value="Larry 3D">Larry 3D</option>
-                    <option value="Roman">Roman</option>
-                    <option value="Shadow">Shadow</option>
-                    <option value="Slant">Slant</option>
-                    <option value="Standard">Standard</option>
-                    <option value="Star Wars">Star Wars</option>
-                </select>
+                    <label for="txt-color">Text color</label>
+                    <input id="txt-color" type="color" value="#000000" />
 
-                <label for="txt-color">Text color</label>
-                <input id="txt-color" type="color" value="#000000" />
+                    <label for="bg-color">Background color</label>
+                    <input id="bg-color" type="color" value="#ffffff" disabled />
 
-                <label for="bg-color">Background color</label>
-                <input id="bg-color" type="color" value="#ffffff" disabled />
+                    <div class="checkbox-row">
+                        <input type="checkbox" id="transparent-bg" checked>
+                        <label for="transparent-bg">Transparent background</label>
+                    </div>
+                    <div class="checkbox-row">
+                        <input type="checkbox" id="shadow">
+                        <label for="shadow">Enable shadow</label>
+                    </div>
 
-                <div class="checkbox-row">
-                    <input type="checkbox" id="transparent-bg" checked>
-                    <label for="transparent-bg">Transparent background</label>
+                    <div id="buttons">
+                        <button id="compareButton" class="btn btn-secondary" type="button">Compare fonts</button>
+                        <a href="#" id="download" download>
+                            <button id="downloadButton" class="btn btn-success" type="button">Download</button>
+                        </a>
+                    </div>
+                </form>
+            </aside>
+
+            <section class="canvas" aria-label="Preview">
+                <div class="spinner-container">
+                    <div class="spinner" role="status" aria-label="Loading"></div>
                 </div>
-                <div class="checkbox-row">
-                    <input type="checkbox" id="shadow">
-                    <label for="shadow">Enable shadow</label>
-                </div>
-            </div>
-
-            <div id="buttons">
-                <a href="#" id="download" download>
-                    <button id="downloadButton" class="btn btn-success" type="button">Download</button>
-                </a>
-                <button id="compareButton" class="btn btn-secondary" type="button">Compare fonts</button>
-            </div>
-        </form>
-
-        <div class="spinner-container">
-            <div class="spinner" role="status" aria-label="Loading"></div>
-        </div>
-        <img id="result" alt="" style="visibility: hidden" />
-
-        <section id="fontGrid" hidden aria-label="Font comparison grid"></section>
+                <img id="result" alt="" style="visibility: hidden" />
+                <section id="fontGrid" hidden aria-label="Font comparison grid"></section>
+            </section>
+        </main>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -127,6 +127,13 @@
                     <div class="spinner" role="status" aria-label="Loading"></div>
                 </div>
                 <img id="result" alt="" style="visibility: hidden" />
+                <section id="fontFocus" hidden aria-label="Font preview">
+                    <header class="font-focus-header">
+                        <span class="font-focus-label"></span>
+                        <button class="font-focus-close" type="button" aria-label="Close preview">&#x2715;</button>
+                    </header>
+                    <div class="font-focus-image"></div>
+                </section>
                 <section id="fontGrid" hidden aria-label="Font comparison grid"></section>
             </section>
         </main>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
+        <meta charset="utf-8">
         <title>README ASCII</title>
 
         <link rel="icon" type="image/png" href="favicon.png">
@@ -44,7 +45,7 @@
             // Set the toggle glyph synchronously so it matches the pre-paint theme.
             (function() {
                 var btn = document.getElementById("themeToggle");
-                if (btn) btn.textContent = document.documentElement.getAttribute("data-theme") === "dark" ? "☀️" : "🌙";
+                if (btn) btn.textContent = document.documentElement.getAttribute("data-theme") === "dark" ? "\u{2600}\u{FE0F}" : "\u{1F319}";
             })();
         </script>
 
@@ -101,6 +102,7 @@
                 <a href="#" id="download" download>
                     <button id="downloadButton" class="btn btn-success" type="button">Download</button>
                 </a>
+                <button id="compareButton" class="btn btn-secondary" type="button">Compare fonts</button>
             </div>
         </form>
 
@@ -108,5 +110,7 @@
             <div class="spinner" role="status" aria-label="Loading"></div>
         </div>
         <img id="result" alt="" style="visibility: hidden" />
+
+        <section id="fontGrid" hidden aria-label="Font comparison grid"></section>
     </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -2,9 +2,11 @@ const DEBOUNCE_MS = 200;
 const SPINNER_DELAY_MS = 300;
 const CONTRAST_THRESHOLD = 4.5; // WCAG AA for normal text
 const FORM_STATE_KEY = "form-state";
+const COMPARE_CONCURRENCY = 4;
 
 let debounceHandle = null;
 let currentGenId = 0;
+let compareOpen = false;
 
 document.addEventListener("DOMContentLoaded", function() {
     initTheme();
@@ -21,10 +23,18 @@ document.addEventListener("DOMContentLoaded", function() {
         saveFormState();
         if (debounceHandle) clearTimeout(debounceHandle);
         if (!asciiText.value) {
-            clearPreview();
+            if (compareOpen) {
+                currentGenId++;
+                document.getElementById("fontGrid").innerHTML = "";
+            } else {
+                clearPreview();
+            }
             return;
         }
-        debounceHandle = setTimeout(generateImage, DEBOUNCE_MS);
+        debounceHandle = setTimeout(() => {
+            if (compareOpen) renderFontGrid();
+            else generateImage();
+        }, DEBOUNCE_MS);
     };
 
     asciiText.addEventListener("input", schedulePreview);
@@ -45,18 +55,21 @@ document.addEventListener("DOMContentLoaded", function() {
         event.preventDefault();
         if (!asciiText.value) return;
         if (debounceHandle) clearTimeout(debounceHandle);
-        generateImage();
+        if (compareOpen) renderFontGrid();
+        else generateImage();
     });
+
+    document.getElementById("compareButton").addEventListener("click", toggleCompare);
 
     const advanced = document.getElementById("advanced");
     const dropdown = document.getElementById("dropdown");
     dropdown.onclick = () => {
         if (advanced.offsetParent === null) {
             advanced.style.display = "block";
-            dropdown.innerText = "▲";
+            dropdown.innerText = "\u{25B2}";
         } else {
             advanced.style.display = "none";
-            dropdown.innerText = "▼";
+            dropdown.innerText = "\u{25BC}";
         }
     };
 
@@ -121,7 +134,7 @@ function currentTheme() {
 function applyTheme(theme) {
     document.documentElement.setAttribute("data-theme", theme);
     const toggle = document.getElementById("themeToggle");
-    if (toggle) toggle.textContent = theme === "dark" ? "☀️" : "🌙";
+    if (toggle) toggle.textContent = theme === "dark" ? "\u{2600}\u{FE0F}" : "\u{1F319}";
     try { localStorage.setItem("theme", theme); } catch (e) { /* private mode */ }
 }
 
@@ -305,4 +318,132 @@ function generateImage() {
         image.setAttribute("src", pngUrl);
         image.style.visibility = "visible";
     });
+}
+
+/* ---------- Compare fonts ---------- */
+
+function getFontList() {
+    return Array.from(document.getElementById("font").options).map(o => o.value);
+}
+
+function currentStyleOptions() {
+    const textColor = document.getElementById("txt-color").value;
+    const transparent = document.getElementById("transparent-bg").checked;
+    const backgroundColor = transparent ? "transparent" : document.getElementById("bg-color").value;
+    const shadow = document.getElementById("shadow").checked;
+    return { textColor, backgroundColor, shadow, transparent };
+}
+
+function figletAsync(text, font) {
+    return new Promise((resolve, reject) => {
+        figlet.text(text, { font }, (err, ascii) => {
+            if (err || !ascii) reject(err || new Error("empty figlet output"));
+            else resolve(ascii);
+        });
+    });
+}
+
+async function renderFontGrid() {
+    const genId = ++currentGenId;
+    const grid = document.getElementById("fontGrid");
+    const text = document.getElementById("asciiText").value;
+    grid.innerHTML = "";
+    if (!text) return;
+
+    const fonts = getFontList();
+    const activeFont = document.getElementById("font").value;
+    const styles = currentStyleOptions();
+
+    const cards = fonts.map(font => {
+        const card = document.createElement("div");
+        card.className = "font-card" + (font === activeFont ? " active" : "");
+        card.dataset.font = font;
+        card.tabIndex = 0;
+        card.setAttribute("role", "button");
+        card.setAttribute("aria-label", `Select font ${font}`);
+
+        const label = document.createElement("div");
+        label.className = "font-card-label";
+        label.textContent = font;
+
+        const preview = document.createElement("div");
+        preview.className = "font-card-preview loading";
+
+        card.appendChild(label);
+        card.appendChild(preview);
+
+        const pick = () => selectFont(font);
+        card.addEventListener("click", pick);
+        card.addEventListener("keydown", (e) => {
+            if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                pick();
+            }
+        });
+
+        grid.appendChild(card);
+        return { font, preview };
+    });
+
+    let next = 0;
+    const workers = Array.from({ length: COMPARE_CONCURRENCY }, async () => {
+        while (next < cards.length) {
+            const i = next++;
+            const { font, preview } = cards[i];
+            try {
+                const ascii = await figletAsync(text, font);
+                if (genId !== currentGenId) return;
+                const pngUrl = asciiToPng(ascii, styles);
+                if (genId !== currentGenId) return;
+                preview.classList.remove("loading");
+                const img = document.createElement("img");
+                img.alt = font;
+                img.src = pngUrl;
+                preview.appendChild(img);
+            } catch (e) {
+                if (genId !== currentGenId) return;
+                preview.classList.remove("loading");
+                preview.classList.add("error");
+                preview.textContent = "Render failed";
+            }
+        }
+    });
+    await Promise.all(workers);
+}
+
+function openCompare() {
+    compareOpen = true;
+    currentGenId++; // invalidate any in-flight single-preview render
+    document.querySelector(".spinner-container").classList.remove("show");
+    document.getElementById("result").style.display = "none";
+    document.getElementById("downloadButton").disabled = true;
+    document.getElementById("fontGrid").hidden = false;
+    document.getElementById("compareButton").textContent = "Close compare";
+    renderFontGrid();
+}
+
+function closeCompare() {
+    compareOpen = false;
+    currentGenId++; // invalidate any in-flight grid renders
+    const grid = document.getElementById("fontGrid");
+    grid.hidden = true;
+    grid.innerHTML = "";
+    const image = document.getElementById("result");
+    image.style.display = "";
+    document.getElementById("compareButton").textContent = "Compare fonts";
+    // Re-enable download only if a previous single preview is still loaded.
+    const hasPreview = !!image.getAttribute("src") && image.style.visibility !== "hidden";
+    document.getElementById("downloadButton").disabled = !hasPreview;
+}
+
+function toggleCompare() {
+    if (compareOpen) closeCompare();
+    else openCompare();
+}
+
+function selectFont(font) {
+    document.getElementById("font").value = font;
+    saveFormState();
+    closeCompare();
+    if (document.getElementById("asciiText").value) generateImage();
 }

--- a/index.js
+++ b/index.js
@@ -61,18 +61,6 @@ document.addEventListener("DOMContentLoaded", function() {
 
     document.getElementById("compareButton").addEventListener("click", toggleCompare);
 
-    const advanced = document.getElementById("advanced");
-    const dropdown = document.getElementById("dropdown");
-    dropdown.onclick = () => {
-        if (advanced.offsetParent === null) {
-            advanced.style.display = "block";
-            dropdown.innerText = "\u{25B2}";
-        } else {
-            advanced.style.display = "none";
-            dropdown.innerText = "\u{25BC}";
-        }
-    };
-
     const themeToggle = document.getElementById("themeToggle");
     themeToggle.addEventListener("click", () => {
         const next = currentTheme() === "dark" ? "light" : "dark";

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const COMPARE_CONCURRENCY = 4;
 let debounceHandle = null;
 let currentGenId = 0;
 let compareOpen = false;
+let focusedFont = null;
 
 document.addEventListener("DOMContentLoaded", function() {
     initTheme();
@@ -25,6 +26,7 @@ document.addEventListener("DOMContentLoaded", function() {
         if (!asciiText.value) {
             if (compareOpen) {
                 currentGenId++;
+                closeFocus();
                 document.getElementById("fontGrid").innerHTML = "";
             } else {
                 clearPreview();
@@ -60,6 +62,21 @@ document.addEventListener("DOMContentLoaded", function() {
     });
 
     document.getElementById("compareButton").addEventListener("click", toggleCompare);
+
+    // Keep the focused-font overlay in sync if the dropdown is used directly.
+    document.getElementById("font").addEventListener("change", () => {
+        if (focusedFont) {
+            focusedFont = document.getElementById("font").value;
+            const label = document.querySelector("#fontFocus .font-focus-label");
+            if (label) label.textContent = focusedFont;
+        }
+    });
+
+    const fontFocus = document.getElementById("fontFocus");
+    fontFocus.querySelector(".font-focus-close").addEventListener("click", closeFocus);
+    document.addEventListener("keydown", (e) => {
+        if (e.key === "Escape" && !fontFocus.hidden) closeFocus();
+    });
 
     const themeToggle = document.getElementById("themeToggle");
     themeToggle.addEventListener("click", () => {
@@ -388,6 +405,7 @@ async function renderFontGrid() {
                 img.alt = font;
                 img.src = pngUrl;
                 preview.appendChild(img);
+                if (focusedFont === font) setFocusImage(font, pngUrl);
             } catch (e) {
                 if (genId !== currentGenId) return;
                 preview.classList.remove("loading");
@@ -413,6 +431,7 @@ function openCompare() {
 function closeCompare() {
     compareOpen = false;
     currentGenId++; // invalidate any in-flight grid renders
+    closeFocus();
     const grid = document.getElementById("fontGrid");
     grid.hidden = true;
     grid.innerHTML = "";
@@ -432,6 +451,39 @@ function toggleCompare() {
 function selectFont(font) {
     document.getElementById("font").value = font;
     saveFormState();
-    closeCompare();
-    if (document.getElementById("asciiText").value) generateImage();
+    document.querySelectorAll(".font-card").forEach(c => {
+        c.classList.toggle("active", c.dataset.font === font);
+    });
+    const card = document.querySelector(`.font-card[data-font="${CSS.escape(font)}"]`);
+    const img = card && card.querySelector(".font-card-preview img");
+    openFocus(font, img ? img.src : null);
+}
+
+function openFocus(font, imgSrc) {
+    focusedFont = font;
+    const overlay = document.getElementById("fontFocus");
+    overlay.querySelector(".font-focus-label").textContent = font;
+    setFocusImage(font, imgSrc);
+    overlay.hidden = false;
+}
+
+function setFocusImage(font, imgSrc) {
+    if (focusedFont !== font) return;
+    const wrap = document.querySelector("#fontFocus .font-focus-image");
+    if (!wrap) return;
+    wrap.innerHTML = "";
+    if (!imgSrc) return;
+    const img = document.createElement("img");
+    img.alt = font;
+    img.src = imgSrc;
+    wrap.appendChild(img);
+}
+
+function closeFocus() {
+    focusedFont = null;
+    const overlay = document.getElementById("fontFocus");
+    if (!overlay) return;
+    overlay.hidden = true;
+    overlay.querySelector(".font-focus-label").textContent = "";
+    overlay.querySelector(".font-focus-image").innerHTML = "";
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1121 @@
+{
+  "name": "readme-ascii",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "readme-ascii",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.49.0",
+        "serve": "^14.2.4"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@zeit/schemas": {
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.36.0.tgz",
+      "integrity": "sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/ansi-align/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/arch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/boxen": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.0.0.tgz",
+      "integrity": "sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.1",
+        "camelcase": "^7.0.0",
+        "chalk": "^5.0.1",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^5.1.2",
+        "type-fest": "^2.13.0",
+        "widest-line": "^4.0.1",
+        "wrap-ansi": "^8.0.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
+      "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clipboardy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-3.0.0.tgz",
+      "integrity": "sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arch": "^2.2.0",
+        "execa": "^5.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-port-reachable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-port-reachable/-/is-port-reachable-4.0.0.tgz",
+      "integrity": "sha512-9UoipoxYmSk6Xy7QFgRv2HDyaysmgSG75TFQs6S+3pDM7ZhKTF/bskZV+0UlABHzKjNVhPjYCLfeZUEg1wXxig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "~1.33.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types/node_modules/mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/registry-auth-token": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha512-ZbgR5aZEdf4UKZVBPYIgaglBmSF2Hi94s2PcIHhRGFjKYu+chjJdYfHn4rt3hB6eCKLJ8giVIIfgMa1ehDfZKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/serve": {
+      "version": "14.2.6",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.6.tgz",
+      "integrity": "sha512-QEjUSA+sD4Rotm1znR8s50YqA3kYpRGPmtd5GlFxbaL9n/FdUNbqMhxClqdditSk0LlZyA/dhud6XNRTOC9x2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@zeit/schemas": "2.36.0",
+        "ajv": "8.18.0",
+        "arg": "5.0.2",
+        "boxen": "7.0.0",
+        "chalk": "5.0.1",
+        "chalk-template": "0.4.0",
+        "clipboardy": "3.0.0",
+        "compression": "1.8.1",
+        "is-port-reachable": "4.0.0",
+        "serve-handler": "6.1.7",
+        "update-check": "1.5.4"
+      },
+      "bin": {
+        "serve": "build/main.js"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/serve-handler": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.7.tgz",
+      "integrity": "sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.0.0",
+        "content-disposition": "0.5.2",
+        "mime-types": "2.1.18",
+        "minimatch": "3.1.5",
+        "path-is-inside": "1.0.2",
+        "path-to-regexp": "3.3.0",
+        "range-parser": "1.2.0"
+      }
+    },
+    "node_modules/serve-handler/node_modules/bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/update-check": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/update-check/-/update-check-1.5.4.tgz",
+      "integrity": "sha512-5YHsflzHP4t1G+8WGPlvKbJEbAJGCgw+Em+dGR1KmBUbr1J36SJBqlHLjR7oob7sco5hWHGQVcr9B2poIVDDTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
+      "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "readme-ascii",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Static site, no build step. Node tooling is dev-only (serve + Playwright).",
+  "scripts": {
+    "start": "serve . -l 8123",
+    "test": "playwright test",
+    "test:headed": "playwright test --headed"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0",
+    "serve": "^14.2.4"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,27 @@
+// @ts-check
+const { defineConfig, devices } = require("@playwright/test");
+
+const PORT = 8124;
+
+module.exports = defineConfig({
+    testDir: "./tests/e2e",
+    timeout: 30_000,
+    expect: { timeout: 5_000 },
+    fullyParallel: false,
+    retries: 0,
+    reporter: process.env.CI ? "github" : "list",
+    use: {
+        baseURL: `http://localhost:${PORT}`,
+        trace: "on-first-retry",
+        screenshot: "only-on-failure",
+    },
+    projects: [
+        { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+    ],
+    webServer: {
+        command: `npx serve . -l ${PORT}`,
+        url: `http://localhost:${PORT}`,
+        reuseExistingServer: !process.env.CI,
+        timeout: 15_000,
+    },
+});

--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -1,0 +1,140 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+
+test.beforeEach(async ({ page }) => {
+    // Ensure a clean form state every run.
+    await page.addInitScript(() => {
+        try { localStorage.clear(); } catch (e) {}
+    });
+    await page.goto("/");
+});
+
+test("single preview renders after typing", async ({ page }) => {
+    await page.fill("#asciiText", "Hello");
+    const result = page.locator("#result");
+    await expect(result).toHaveAttribute("src", /^data:image\/png/, { timeout: 10_000 });
+    await expect(result).toBeVisible();
+    await expect(page.locator("#downloadButton")).toBeEnabled();
+});
+
+test.describe("compare grid", () => {
+    test("opens, renders cards for every font option, then closes", async ({ page }) => {
+        await page.fill("#asciiText", "Hello");
+        await page.locator("#result").waitFor({ state: "visible" });
+
+        const fontCount = await page.locator("#font option").count();
+        expect(fontCount).toBeGreaterThan(1);
+
+        await page.click("#compareButton");
+        await expect(page.locator("#compareButton")).toHaveText("Close compare");
+        await expect(page.locator("#fontGrid")).toBeVisible();
+
+        const cards = page.locator(".font-card");
+        await expect(cards).toHaveCount(fontCount);
+
+        // Wait for every preview image to actually render.
+        await expect(page.locator(".font-card-preview img")).toHaveCount(fontCount, { timeout: 20_000 });
+
+        // The currently-selected font has the active ring.
+        const selectedFont = await page.locator("#font").inputValue();
+        await expect(page.locator(`.font-card[data-font="${selectedFont}"]`)).toHaveClass(/active/);
+
+        // Close via the same toggle button.
+        await page.click("#compareButton");
+        await expect(page.locator("#fontGrid")).toBeHidden();
+        await expect(page.locator("#result")).toBeVisible();
+    });
+
+    test("live-updates cards when styling changes", async ({ page }) => {
+        await page.fill("#asciiText", "Hello");
+        await page.click("#compareButton");
+        await page.locator(".font-card-preview img").first().waitFor({ timeout: 20_000 });
+
+        const firstCard = page.locator(`.font-card[data-font="Alpha"] .font-card-preview img`);
+        const initialSrc = await firstCard.getAttribute("src");
+
+        // Toggle shadow and ensure the rendered PNG changes.
+        await page.locator("#shadow").check();
+        await expect.poll(
+            async () => firstCard.getAttribute("src"),
+            { timeout: 15_000 }
+        ).not.toBe(initialSrc);
+    });
+});
+
+test.describe("font focus overlay (theater mode)", () => {
+    test("clicking a card opens focus, selects font, keeps compare open", async ({ page }) => {
+        await page.fill("#asciiText", "Hello");
+        await page.click("#compareButton");
+        await page.locator(".font-card-preview img").first().waitFor({ timeout: 20_000 });
+
+        // Click a non-default card.
+        const targetFont = "Doom";
+        await page.locator(`.font-card[data-font="${targetFont}"]`).click();
+
+        // Focus overlay visible, label shows the font name.
+        const overlay = page.locator("#fontFocus");
+        await expect(overlay).toBeVisible();
+        await expect(overlay.locator(".font-focus-label")).toHaveText(targetFont);
+        await expect(overlay.locator(".font-focus-image img")).toBeVisible();
+
+        // Font dropdown updated.
+        await expect(page.locator("#font")).toHaveValue(targetFont);
+
+        // Active card ring moved to the clicked card.
+        await expect(page.locator(`.font-card[data-font="${targetFont}"]`)).toHaveClass(/active/);
+
+        // Compare grid is still open (button still says Close compare, grid still visible).
+        await expect(page.locator("#compareButton")).toHaveText("Close compare");
+        await expect(page.locator("#fontGrid")).toBeVisible();
+    });
+
+    test("ESC closes focus, leaves compare open", async ({ page }) => {
+        await page.fill("#asciiText", "Hi");
+        await page.click("#compareButton");
+        await page.locator(".font-card-preview img").first().waitFor({ timeout: 20_000 });
+        await page.locator(`.font-card[data-font="Big"]`).click();
+        await expect(page.locator("#fontFocus")).toBeVisible();
+
+        await page.keyboard.press("Escape");
+        await expect(page.locator("#fontFocus")).toBeHidden();
+        await expect(page.locator("#fontGrid")).toBeVisible();
+    });
+
+    test("close button dismisses focus, grid remains", async ({ page }) => {
+        await page.fill("#asciiText", "Hi");
+        await page.click("#compareButton");
+        await page.locator(".font-card-preview img").first().waitFor({ timeout: 20_000 });
+        await page.locator(`.font-card[data-font="Big"]`).click();
+        const panel = page.locator("#fontFocus");
+        await expect(panel).toBeVisible();
+
+        await panel.locator(".font-focus-close").click();
+        await expect(panel).toBeHidden();
+        await expect(page.locator("#fontGrid")).toBeVisible();
+    });
+
+    test("focus panel is inline inside the canvas, not a fullscreen overlay", async ({ page }) => {
+        await page.fill("#asciiText", "Hi");
+        await page.click("#compareButton");
+        await page.locator(".font-card-preview img").first().waitFor({ timeout: 20_000 });
+        await page.locator(`.font-card[data-font="Big"]`).click();
+        await expect(page.locator(".canvas > #fontFocus")).toBeVisible();
+        // The sidebar must remain interactive (i.e. not covered by the focus panel).
+        await expect(page.locator("#compareButton")).toBeVisible();
+        await page.click("#compareButton"); // sidebar reachable while focus open
+        await expect(page.locator("#fontFocus")).toBeHidden();
+        await expect(page.locator("#fontGrid")).toBeHidden();
+    });
+
+    test("dropdown change while focused updates the overlay label", async ({ page }) => {
+        await page.fill("#asciiText", "Hi");
+        await page.click("#compareButton");
+        await page.locator(".font-card-preview img").first().waitFor({ timeout: 20_000 });
+        await page.locator(`.font-card[data-font="Big"]`).click();
+        await expect(page.locator("#fontFocus .font-focus-label")).toHaveText("Big");
+
+        await page.selectOption("#font", "Slant");
+        await expect(page.locator("#fontFocus .font-focus-label")).toHaveText("Slant");
+    });
+});


### PR DESCRIPTION
## Summary

Reshape the app from a centered single-column form into a studio-style layout, then add a compare-fonts mode and an inline theater preview, plus a Playwright E2E suite to keep it honest.

### Layout
- New top bar with a small 36px brand chip (replacing the giant banner) and the theme toggle inline.
- CSS-grid app shell: 280px sidebar with all controls always visible (the advanced dropdown toggle is gone) and a hero canvas column on the right. Stacks to a single column below 720px.
- Added social meta tags (description, canonical, Open Graph, Twitter card) and a real `<meta charset="utf-8">` (which surfaced a charset bug: external JS served without a charset header was being decoded as latin-1, so emoji glyphs rendered as mojibake; fixed by switching the affected string literals to `\u` escapes so source bytes are pure ASCII).

### Compare fonts
- "Compare fonts" button opens a responsive card grid (one card per font in the dropdown).
- Each card streams in via a 4-wide promise pool with cancellation tied to the existing `currentGenId` pattern.
- Live styling: editing text, font, colors, shadow, or transparency while the grid is open re-renders every card (debounced).
- Currently-selected font gets a green ring.

### Theater preview
- Clicking a card promotes that font into an inline panel above the grid (YouTube-theater style, no full-screen modal), selects it in the dropdown, and keeps the grid open below.
- Sidebar stays fully interactive; close via the X button or ESC. Changing the dropdown while focused updates the panel.

### Tooling
- `npm install` + `npm start` (via `serve`) and `npm test` (Playwright). Node-only toolchain, no Python.
- `tests/e2e/app.spec.js` covers single preview, compare grid open/close + per-font render + active state + live styling, theater open / dropdown sync / ESC / close button / inline-not-overlay assertions, and `closeCompare` cleanup.
- The suite caught a real bug in the first run: `#fontFocus { display: flex }` was overriding the UA `[hidden]` rule (ID specificity beats attribute selector), so the "hidden" overlay was covering the viewport invisibly and swallowing every click. Fix is one CSS rule.

## Test plan

- [x] `npm install`
- [x] `npx playwright install chromium`
- [x] `npm test` (expect 8 passing)
- [x] `npm start` and visit http://localhost:8123/
  - [x] Type into the sidebar; preview updates live
  - [x] Toggle theme; preview and brand swap correctly
  - [x] Open Compare fonts; cards stream in; active font has a green ring
  - [x] Edit color/shadow with compare open; every card re-renders
  - [x] Click a card; inline theater panel appears above the grid; font dropdown updates; grid remains visible
  - [x] Press ESC or click the X; theater closes, grid remains
  - [x] Close compare; download still works for the last selected font
  - [x] Resize to mobile width; sidebar stacks above canvas